### PR TITLE
Add check for __file__ when getting programName

### DIFF
--- a/regr/program/program.py
+++ b/regr/program/program.py
@@ -32,9 +32,12 @@ class dbUpdate():
         self.cwd = os.path.basename(self.cwd)
 
         import __main__
-        self.programName = os.path.basename(__main__.__file__)
-        if self.programName.index('.') >= 0:
-            self.programName = self.programName[:self.programName.index('.')]
+        if hasattr(__main__, '__file__'):
+            self.programName = os.path.basename(__main__.__file__)
+            if self.programName.index('.') >= 0:
+                self.programName = self.programName[:self.programName.index('.')]
+        else:
+            self.programName = ''
 
         try:
             import os


### PR DESCRIPTION
IPython notebooks don't have a __file__ attribute, causing it to throw an error when attempting to get programName.

Particularly, here's the code the replicate it: https://colab.research.google.com/drive/11sqYyV7lJz6hNZ4yYuLp2p33wvzkueDT?usp=sharing
It throws an AttributeError when initializing SolverPOIProgram.

There doesn't seem to be a good way to get the filename of a IPython notebook.