### PR TITLE
Fix the datanode issue

### DIFF
--- a/domiknows/graph/dataNode.py
+++ b/domiknows/graph/dataNode.py
@@ -2586,19 +2586,19 @@ class DataNodeBuilder(dict):
                     incomingLinks[dn] = 1
 
         # Find the root dataNodes which have no incoming links
-        # newDnsRoots = [dn for dn in allDns if (incomingLinks[dn] == 0 or not dn.impactLinks)]
-        newDnsRoots = newDnsRoots = [dn for dn in allDns if (incomingLinks[dn] == 0 or not dn.impactLinks) and not str(dn)=="constraint 0"]
+        newDnsRoots = [dn for dn in allDns if (incomingLinks[dn] == 0 or not dn.impactLinks)]
         newDnsRoots = sorted(newDnsRoots, key=lambda dn: len(dnTypes[dn.ontologyNode]), reverse=False)
 
         # if newDnsRoots is empty
         if not newDnsRoots:
             newDnsRoots = allDns
-            #newDnsRoots = sorted(newDnsRoots, key=lambda dn: incomingLinks[dn], reverse=True)
             newDnsRoots = sorted(newDnsRoots, key=lambda dn: len(dnTypes[dn.ontologyNode]), reverse=False)
 
         # Set the updated root list
         if not getProductionModeStatus():
             _DataNodeBuilder__Logger.info('Updated elements in the root dataNodes list - %s'%(newDnsRoots))
+        if newDnsRoots:
+            if str(newDnsRoots[0])=="constraint 0": newDnsRoots = newDnsRoots[1:]+[newDnsRoots[0]]
         dict.__setitem__(self, 'dataNode', newDnsRoots) # Updated the dict
 
         return


### PR DESCRIPTION
Root Data node is always selected from the first concept in the list, such as in line 3561: rootDn = existingDns[0]
so I put the constraint concept at the end of the list and it's never selected again.