### PR TITLE
Add iffL (if-and-only-if) biconditional constraint support (#378)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,6 +105,7 @@ jobs:
           retention-days: 1
 
   test-gpu:
+    if: github.repository == 'HLR/DomiKnowS'
     runs-on: [self-hosted, linux, x64, gpu]
     steps:
       - uses: actions/checkout@v6

--- a/domiknows/README.md
+++ b/domiknows/README.md
@@ -228,7 +228,7 @@ program.test(test_data, device='cuda')
 - **Weak supervision**: Learn from partial labels + domain knowledge
 
 ### Flexible Constraint Types
-- **Logical**: AND, OR, NOT, IF, equivalence
+- **Logical**: AND, OR, NOT, IF, IFF (equivalence)
 - **Quantifiers**: exists, forall, counting constraints
 - **Paths**: Express constraints over graph structure
 - **Priorities**: Soft vs. hard constraints

--- a/domiknows/graph/README_GRAPH.md
+++ b/domiknows/graph/README_GRAPH.md
@@ -501,6 +501,12 @@ ifL(
 equivalenceL(person('x'), entity('x'))
 ```
 
+##### `iffL` - If and Only If (alias)
+```python
+# Exact alias of equivalenceL
+iffL(person('x'), entity('x'))
+```
+
 ##### `forAllL` - Universal Quantifier
 ```python
 # ∀x: person(x) → entity(x)

--- a/domiknows/graph/__init__.py
+++ b/domiknows/graph/__init__.py
@@ -2,7 +2,7 @@ from .graph import Graph
 from .concept import Concept, EnumConcept
 from .relation import Relation
 from .logicalConstrain import LcElement, LogicalConstrain, V, execute
-from .logicalConstrain import andL, nandL, orL, ifL, norL, xorL, notL, equivalenceL
+from .logicalConstrain import andL, nandL, orL, ifL, norL, xorL, notL, equivalenceL, iffL
 from .logicalConstrain import eqL, fixedL, forAllL
 from .logicalConstrain import existsL, atLeastL, atMostL, exactL
 from .logicalConstrain import existsAL, atLeastAL, atMostAL, exactAL

--- a/domiknows/graph/lcUtils.py
+++ b/domiknows/graph/lcUtils.py
@@ -1,4 +1,5 @@
-from collections import namedtuple
+﻿from collections import namedtuple
+from difflib import get_close_matches
 
 from domiknows.graph import V, CandidateSelection, Concept, LogicalConstrain
 
@@ -315,6 +316,34 @@ def _raise_missing_concept_error(graph, lc_name, concept_name, constraint_type,
     
     raise ValueError(error_msg)
 
+
+def _raise_undefined_variable(variable_name, lc_context, lc_path, found_variables):
+    """Raise a clear error when a variable used in a path was never defined in the constraint.
+
+    Includes 'did you mean' suggestions based on edit distance against already-defined
+    variable names so that common typos (e.g. 'e1' vs 'el1') are caught early.
+    """
+    defined_vars = sorted(v for v in found_variables if isinstance(v, str))
+    close = get_close_matches(variable_name, defined_vars, n=3, cutoff=0.5)
+
+    msg = f"Variable '{variable_name}' used in {lc_context} is not defined."
+
+    if lc_path is not None:
+        msg += f"\n  Used in path: {lc_path}"
+
+    msg += (
+        f"\n  You must first introduce '{variable_name}' as a direct argument "
+        f"(without a path) before referencing it inside a path."
+    )
+
+    if close:
+        msg += f"\n  Did you mean: {', '.join(repr(c) for c in close)}?"
+    elif defined_vars:
+        msg += f"\n  Variables defined in this constraint: {', '.join(defined_vars)}"
+
+    raise ValueError(msg)
+
+
 def _iter_all_lcs(graph):
         """Helper to iterate over all logical constraints including executable ones.
         
@@ -364,7 +393,7 @@ def find_lc_variable(lc, found_variables=None, headLc=None):
             exceptionStr1 = f"{lc.typeName} {headLc} has incorrect cardinality definition - "
         
         exceptionStr2 = f"integer {lc.cardinalityException} has to be last element in the same Logical operator for counting or existing logical operators!"
-        raise Exception(f"{exceptionStr1} {exceptionStr2}")
+        raise ValueError(f"{exceptionStr1} {exceptionStr2}")
 
     if found_variables is None:
         found_variables = {}
@@ -384,14 +413,14 @@ def find_lc_variable(lc, found_variables=None, headLc=None):
                     found_variables[variable_name] = variable_info
             else:
                 exceptionStr = f"In logical constraint {lc_context} variable {variable_name} is not associated with any concept"
-                raise Exception(exceptionStr)
+                raise ValueError(exceptionStr)
             
         # checking for extra variable:
         elif e and isinstance(e, tuple) and e[0] == 'extraV':
             predicate = lc.e[0][1]
             exceptionStr1 = f"Logical constraint {lc_context}: Each predicate can only have one new variable definition. For the predicate {predicate}, you have used both {e[1]} and {e[2]} as new variables."
             exceptionStr2 = f"Either wrap both under on variable, if you intended to initialize {e[1]} based on another value, then the second argument should be a path=(...)."
-            raise Exception(f"{exceptionStr1} {exceptionStr2}")
+            raise ValueError(f"{exceptionStr1} {exceptionStr2}")
         # checking if element is a tuple 
         elif isinstance(e, tuple) and e and isinstance(e[0], LcElement) and not isinstance(e[0], LogicalConstrain):
             find_lc_variable(e[0], found_variables=found_variables, headLc=headLc)
@@ -399,12 +428,12 @@ def find_lc_variable(lc, found_variables=None, headLc=None):
             current_lc_element_concepts = [c for c in current_lc_element.e if isinstance(c, tuple) and not isinstance(c, V)]
 
             if len(current_lc_element_concepts) != len(e[1]):
-                raise Exception(f"Logical constraint {lc_context} has incorrect definition of combination {e} - number of variables does not match number of concepts in combination")
+                raise ValueError(f"Logical constraint {lc_context} has incorrect definition of combination {e} - number of variables does not match number of concepts in combination")
 
             if len(e) >= 2 and isinstance(e[1], tuple):
                 for v in e[1]:
                     if not isinstance(v, str):
-                        raise Exception(f"Logical constraint {lc_context} has incorrect definition of combination {e} - all variables should be strings")
+                        raise ValueError(f"Logical constraint {lc_context} has incorrect definition of combination {e} - all variables should be strings")
 
                 for index, v in enumerate(e[1]):
                     variable_name = v
@@ -518,7 +547,7 @@ def check_if_all_used_variables_are_defined(lc, found_variables, used_variables=
                             (fallback_object, fallback_object.name, None, 1),
                         )
                     else:
-                        raise Exception(f"Variable {lc_variable_name} found in {lc_context} is not defined. You should first use {lc_variable_name} without putting it in a path to define it.")
+                        _raise_undefined_variable(lc_variable_name, lc_context, lcPath, found_variables)
 
         if lc_variable_name not in used_variables:
             used_variables[lc_variable_name] = []
@@ -540,11 +569,11 @@ def check_if_all_used_variables_are_defined(lc, found_variables, used_variables=
                         if isinstance(t[0], str):
                             handle_variable_name(t[0], t)
                         else:
-                            raise Exception(f"Path {t} found in {lc_context} is not correct")
+                            raise ValueError(f"Path {t} found in {lc_context} is not correct")
                 else:
-                    raise Exception(f"Path {e} found in {lc_context} is not correct")
+                    raise ValueError(f"Path {e} found in {lc_context} is not correct")
             else:
-                raise Exception(f"Path {e} found in {lc_context} is not correct")
+                raise ValueError(f"Path {e} found in {lc_context} is not correct")
         elif isinstance(e, LogicalConstrain):
             check_if_all_used_variables_are_defined(e, found_variables, used_variables=used_variables, headLc=headLc, graph=graph)
 
@@ -605,10 +634,10 @@ def check_path(graph, path, resultConcept, variableConceptParent, lc_name, found
         """Check if ancestor_name is an ancestor of descendant_concept via is_a chain.
 
         In an andL, a variable like 'x' can satisfy multiple predicates
-        simultaneously — e.g. brown('x') says x has color=brown, while
+        simultaneously â€” e.g. brown('x') says x has color=brown, while
         right_of('z', 'x') says x is an object.  The relation endpoint
-        (object) is an ancestor of the variable's declared concept (brown →
-        color → … → object) through the containment hierarchy, so the path
+        (object) is an ancestor of the variable's declared concept (brown â†’
+        color â†’ â€¦ â†’ object) through the containment hierarchy, so the path
         is valid even though the types don't match directly.
         """
         current = descendant_concept
@@ -622,7 +651,7 @@ def check_path(graph, path, resultConcept, variableConceptParent, lc_name, found
             if parents:
                 current = parents[0].dst
             else:
-                # Walk up contains (child → parent)
+                # Walk up contains (child â†’ parent)
                 containers = current._in.get('contains', [])
                 if containers:
                     current = containers[0].src
@@ -646,7 +675,7 @@ def check_path(graph, path, resultConcept, variableConceptParent, lc_name, found
             exceptionStr1 = f"The variable {pathVariable}, defined in the path for {lc_name} is not valid. The concept of {pathVariable} is a of type {requiredLeftConcept},"
             exceptionStr2 = f"but the required concept by the logical constraint element is {requiredEndOfPathConceptRoot}."
             exceptionStr3 = f"The variable used inside the path should match its type with {requiredEndOfPathConceptRoot}."
-            raise Exception(f"{exceptionStr1} {exceptionStr2} {exceptionStr3}")
+            raise ValueError(f"{exceptionStr1} {exceptionStr2} {exceptionStr3}")
         
     for pathIndex, pathElement in enumerate(path[1:], start=1):   
         if isinstance(pathElement, (eqL,)):
@@ -658,7 +687,7 @@ def check_path(graph, path, resultConcept, variableConceptParent, lc_name, found
                 exceptionStr1 = f"The Path '{pathStr}' from the variable {pathVariable}, defined in {lc_name} is not valid."
                 exceptionStr2 = f"The required source type after {pathPart} is a {requiredLeftConcept},"
                 exceptionStr3 = f"but the used variable {pathElement} is a string which is not a valid name of a graph relationship."
-                raise Exception(f"{exceptionStr1} {exceptionStr2} {exceptionStr3}")
+                raise ValueError(f"{exceptionStr1} {exceptionStr2} {exceptionStr3}")
             
         if pathIndex < len(path) - 1:
             expectedRightConcept = pathElement.dst
@@ -674,7 +703,7 @@ def check_path(graph, path, resultConcept, variableConceptParent, lc_name, found
             pathElementVarName = pathElement.var_name if pathElement.var_name else ""
 
             # In an andL, a variable may satisfy multiple predicates.
-            # E.g. brown('x'), right_of('z', 'x') — x is both a "brown"
+            # E.g. brown('x'), right_of('z', 'x') â€” x is both a "brown"
             # (color attribute) and an "object" (relation endpoint).
             # The relation src/dst may be an ancestor of the variable's
             # declared concept, which is valid.
@@ -697,13 +726,13 @@ def check_path(graph, path, resultConcept, variableConceptParent, lc_name, found
                 else:
                     exceptionStr3 = f"You can change  '{pathElement.var_name}.reversed' to '{pathElement.var_name}' to go from {pathElementSrc} to the {pathElementDst}, which is what is required here."
                     f"You can use without the .reversed property to change the direction."
-                raise Exception(f"{exceptionStr1} {exceptionStr2} {exceptionStr3}")
+                raise ValueError(f"{exceptionStr1} {exceptionStr2} {exceptionStr3}")
             # Check if the current path element is correctly connected to the left (source) - has matching type
             elif not srcCompatible:
                 exceptionStr1 = f"The Path '{pathStr}' from the variable {pathVariable}, defined in {lc_name} is not valid."
                 exceptionStr2 = f"The required source type after {pathPart} is a {requiredLeftConcept},"
                 exceptionStr3 = f"but the used variable {pathElementVarName} is a relationship defined between a {pathElementSrc} and a {pathElementDst}, which is not correctly used here."
-                raise Exception(f"{exceptionStr1} {exceptionStr2} {exceptionStr3}")
+                raise ValueError(f"{exceptionStr1} {exceptionStr2} {exceptionStr3}")
             # Check if the current path element is correctly connected to the right (destination) - has matching type
             elif not dstCompatible:
                 exceptionStr1 = f"The Path '{pathStr}' from the variable {pathVariable}, defined in {lc_name} is not valid."
@@ -712,7 +741,7 @@ def check_path(graph, path, resultConcept, variableConceptParent, lc_name, found
                 else: # if this it intermediary path element that if is expected that it will match next path element source type
                     exceptionStr2 = f"The expected destination type after {pathPart} is a {expectedRightConcept}."
                 exceptionStr3 = f"The used variable {pathElementVarName} is a relationship defined between a {pathElementSrc} and a {pathElementDst}, which is not correctly used here."
-                raise Exception(f"{exceptionStr1} {exceptionStr2} {exceptionStr3}")
+                raise ValueError(f"{exceptionStr1} {exceptionStr2} {exceptionStr3}")
             
             # Move along the path with the requiredLeftConcept and pathVariable
             requiredLeftConcept = pathElementDst
@@ -724,12 +753,12 @@ def check_path(graph, path, resultConcept, variableConceptParent, lc_name, found
                 exceptionStr3 = f"- If you meant that '{pathVariable}' should be of type {expectedRightConcept}: {expectedRightConcept}(path=('{pathVariable}'))"
                 exceptionStr4 = f"- If you meant another entity 'y' should be of type {expectedRightConcept} which is somehow related to '{pathVariable}': {expectedRightConcept}(path=('x', edge1, edge2, ...))"
                 exceptionStr5 = f"where edge1, edge2, ... are relations that connect '{pathVariable}' to 'y'."
-                raise Exception(f"{exceptionStr1} {exceptionStr2} {exceptionStr3} {exceptionStr4} {exceptionStr5}")
+                raise ValueError(f"{exceptionStr1} {exceptionStr2} {exceptionStr3} {exceptionStr4} {exceptionStr5}")
             else: # all other types not allowed in path
                 pathElementType = type(pathElement)
                 exceptionStr1 = f"The Path '{pathStr}' from the variable {pathVariable}, after {pathPart} is not valid."
                 exceptionStr2 = f"The used variable {pathElement} is a {pathElementType}, path element can be only relation or eqL logical constraint used to filter candidates in the path."
-                raise Exception(f"{exceptionStr1} {exceptionStr2}")
+                raise ValueError(f"{exceptionStr1} {exceptionStr2}")
 
 def are_keys_new(given_dict, dict_list):
     """
@@ -925,7 +954,7 @@ def validate_queryL_constraints(graph, lc, headLc=None):
             if not hasattr(concept, 'enum') or not concept.enum:
                 exceptionStr1 = f"queryL constraint in {headLc} has invalid EnumConcept '{concept_name}'."
                 exceptionStr2 = f"EnumConcept must have non-empty 'enum' values defined."
-                raise Exception(f"{exceptionStr1} {exceptionStr2}")
+                raise ValueError(f"{exceptionStr1} {exceptionStr2}")
             # Valid EnumConcept
             return
         
@@ -944,7 +973,7 @@ def validate_queryL_constraints(graph, lc, headLc=None):
                 exceptionStr2 = f"The concept used in queryL must be a multiclass concept with subclasses defined via is_a()."
                 exceptionStr3 = f"Example: metal.is_a({concept_name}), rubber.is_a({concept_name})"
                 exceptionStr4 = f"Alternatively, use EnumConcept: {concept_name} = EnumConcept('{concept_name}', values=['value1', 'value2'])"
-                raise Exception(f"{exceptionStr1} {exceptionStr2} {exceptionStr3} {exceptionStr4}")
+                raise ValueError(f"{exceptionStr1} {exceptionStr2} {exceptionStr3} {exceptionStr4}")
             
             # Valid - concept has subclasses
             return
@@ -952,7 +981,7 @@ def validate_queryL_constraints(graph, lc, headLc=None):
         # Neither EnumConcept nor Concept
         exceptionStr1 = f"queryL constraint in {headLc} has invalid concept type: {type(concept)}."
         exceptionStr2 = f"The first argument to queryL must be a Concept with is_a subclasses or an EnumConcept."
-        raise Exception(f"{exceptionStr1} {exceptionStr2}")
+        raise ValueError(f"{exceptionStr1} {exceptionStr2}")
     
     # Recursively check nested logical constraints
     for e in lc.e:
@@ -980,7 +1009,7 @@ def _validate_counting_constraints(lc, lc_name):
         if isinstance(lc, counting_types):
             # Check if constraint has elements to count
             if not lc.e or len(lc.e) == 0:
-                raise Exception(
+                raise ValueError(
                     f"Counting constraint '{lc_name}' ({type(lc).__name__}) has no elements to count"
                 )
             
@@ -993,7 +1022,7 @@ def _validate_counting_constraints(lc, lc_name):
                 limit = 1  # default
             
             if isinstance(limit, int) and limit < 0:
-                raise Exception(
+                raise ValueError(
                     f"Counting constraint '{lc_name}' ({type(lc).__name__}) has negative limit: {limit}"
                 )
         
@@ -1032,7 +1061,7 @@ def _validate_relations_in_constraints(graph, allConceptNames, lc, lc_name):
                         
                         # Validate has_a has at least 2 destinations
                         if len(has_a_relations) < 2:
-                            raise Exception(
+                            raise ValueError(
                                 f"Relation concept '{concept.name}' in '{lc_name}' has only {len(has_a_relations)} destination(s), but has_a requires at least 2"
                             )
                         
@@ -1040,7 +1069,7 @@ def _validate_relations_in_constraints(graph, allConceptNames, lc, lc_name):
                         for rel in has_a_relations:
                             dest_name = rel.dst.name if hasattr(rel.dst, 'name') else str(rel.dst)
                             if dest_name not in allConceptNames:
-                                raise Exception(
+                                raise ValueError(
                                     f"Relation '{concept.name}' in '{lc_name}' references destination concept '{dest_name}' which is not in the graph"
                                 )
                 

--- a/domiknows/graph/logicalConstrain.py
+++ b/domiknows/graph/logicalConstrain.py
@@ -925,6 +925,15 @@ class equivalenceL(LogicalConstrain):
         with torch.set_grad_enabled(myConstraintVarProcessor.grad): 
             return self.createLogicalConstrains('Equivalence', myConstraintVarProcessor.equivalenceVar, model, v, headConstrain)
 
+
+class iffL(equivalenceL):
+    """Bi-conditional logical constraint (A ↔ B).
+
+    This is a user-facing alias for `equivalenceL`.
+    Semantics: true when all provided operands have the same truth value.
+    """
+    pass
+
 # ----------------- Counting
 
 class _CountBaseL(LogicalConstrain):

--- a/domiknows/solver/adaptiveTNormLossCalculator.py
+++ b/domiknows/solver/adaptiveTNormLossCalculator.py
@@ -47,6 +47,8 @@ DEFAULT_TNORM_BY_TYPE = {
     'nandL': 'SP',
     'norL': 'SP',
     'ifL': 'P',
+    'equivalenceL': 'P',
+    'iffL': 'P',
     'existsL': 'L',
     'notL': 'SP',
     # Fallback

--- a/test_regr/solver/test_iff_constraint.py
+++ b/test_regr/solver/test_iff_constraint.py
@@ -1,0 +1,76 @@
+import torch
+
+from domiknows.graph import iffL as iffL_export
+from domiknows.graph import equivalenceL
+from domiknows.graph.logicalConstrain import iffL
+from domiknows.solver.booleanMethodsCalculator import booleanMethodsCalculator
+from domiknows.solver.lcLossBooleanMethods import lcLossBooleanMethods
+
+
+def _to_scalar(value):
+    if torch.is_tensor(value):
+        return float(value.detach().reshape(-1)[0].item())
+    return float(value)
+
+
+def test_iff_export_and_alias():
+    assert iffL_export is iffL
+    assert issubclass(iffL, equivalenceL)
+
+
+def test_iff_truth_table_boolean_backend():
+    calc = booleanMethodsCalculator()
+    calc.current_device = torch.device("cpu")
+
+    # (A, B, expected A<->B)
+    cases = [
+        (1, 1, 1),
+        (0, 0, 1),
+        (1, 0, 0),
+        (0, 1, 0),
+    ]
+
+    for a, b, expected in cases:
+        assert calc.equivalenceVar(None, a, b) == expected
+
+
+def test_iff_truth_table_loss_backend():
+    calc = lcLossBooleanMethods()
+    calc.current_device = torch.device("cpu")
+    calc.setTNorm("P")
+
+    # Hard truth assignments should produce hard biconditional outputs in [0, 1].
+    cases = [
+        (1.0, 1.0, 1.0),
+        (0.0, 0.0, 1.0),
+        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+    ]
+
+    for a, b, expected_success in cases:
+        a_t = torch.tensor([a], dtype=torch.float32, device=calc.current_device)
+        b_t = torch.tensor([b], dtype=torch.float32, device=calc.current_device)
+
+        success = calc.equivalenceVar(None, a_t, b_t, onlyConstrains=False)
+        loss = calc.equivalenceVar(None, a_t, b_t, onlyConstrains=True)
+
+        assert _to_scalar(success) == expected_success
+        assert _to_scalar(loss) == (1.0 - expected_success)
+
+
+def test_iff_edge_cases_boolean_backend():
+    calc = booleanMethodsCalculator()
+    calc.current_device = torch.device("cpu")
+
+    # Vacuous edge cases
+    assert calc.equivalenceVar(None) == 1
+    assert calc.equivalenceVar(None, 1) == 1
+
+    # None is treated as False in equivalenceVar.
+    assert calc.equivalenceVar(None, None, 0) == 1
+    assert calc.equivalenceVar(None, None, 1) == 0
+
+    # N-ary behavior: true iff all values are identical.
+    assert calc.equivalenceVar(None, 0, 0, 0) == 1
+    assert calc.equivalenceVar(None, 1, 1, 1) == 1
+    assert calc.equivalenceVar(None, 1, 1, 0) == 0

--- a/test_regr/test_lc_error_reporting.py
+++ b/test_regr/test_lc_error_reporting.py
@@ -1,0 +1,153 @@
+"""
+Regression tests for issue #376 — better error reporting in logical constraints.
+
+Verifies that:
+1. Undefined variables in LC paths raise ValueError (not generic Exception)
+2. Error messages include 'did you mean' suggestions for typos
+3. Error messages include the offending path
+4. Valid constraints still pass without error
+"""
+import pytest
+import sys
+import os
+import re
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from domiknows.graph import Graph, Concept, Relation, ifL, notL, andL, nandL
+
+
+# ---------- helpers ----------
+
+def _build_simple_graph():
+    """sentence -> word -> tag, with contains relations."""
+    with Graph('test_lc_err') as g:
+        sentence = Concept('sentence')
+        word = Concept('word')
+        tag = Concept('tag')
+        (s_w,) = sentence.contains(word)
+        (w_t,) = word.contains(tag)
+    return g, sentence, word, tag, s_w, w_t
+
+
+# ---------- undefined variable detection ----------
+
+class TestUndefinedVariableError:
+    def test_typo_raises_valueerror(self):
+        """Using 'e1' instead of 'el1' must raise ValueError."""
+        with pytest.raises(ValueError, match="not defined"):
+            _build_simple_graph()  # clear state first
+            with Graph('g') as g:
+                sentence = Concept('sentence')
+                word = Concept('word')
+                tag = Concept('tag')
+                (s_w,) = sentence.contains(word)
+                (w_t,) = word.contains(tag)
+                ifL(
+                    word('el1'),
+                    notL(tag('t1', path=(('e1', s_w, w_t),)))
+                )
+
+    def test_error_suggests_correct_variable(self):
+        """The error message should suggest 'el1' for mistyped 'e1'."""
+        with pytest.raises(ValueError, match=r"Did you mean.*'el1'"):
+            with Graph('g2') as g:
+                sentence = Concept('sentence')
+                word = Concept('word')
+                tag = Concept('tag')
+                (s_w,) = sentence.contains(word)
+                (w_t,) = word.contains(tag)
+                ifL(
+                    word('el1'),
+                    notL(tag('t1', path=(('e1', s_w, w_t),)))
+                )
+
+    def test_error_includes_path(self):
+        """The error message should mention the offending path."""
+        with pytest.raises(ValueError, match="Used in path"):
+            with Graph('g3') as g:
+                sentence = Concept('sentence')
+                word = Concept('word')
+                tag = Concept('tag')
+                (s_w,) = sentence.contains(word)
+                (w_t,) = word.contains(tag)
+                ifL(
+                    word('el1'),
+                    notL(tag('t1', path=(('e1', s_w, w_t),)))
+                )
+
+    def test_completely_unknown_variable(self):
+        """A variable name with no close match still raises ValueError."""
+        with pytest.raises(ValueError, match="not defined"):
+            with Graph('g4') as g:
+                sentence = Concept('sentence')
+                word = Concept('word')
+                tag = Concept('tag')
+                (s_w,) = sentence.contains(word)
+                (w_t,) = word.contains(tag)
+                ifL(
+                    word('w1'),
+                    notL(tag('t1', path=(('zzz_nonexistent', s_w, w_t),)))
+                )
+
+    def test_unknown_variable_lists_defined_vars(self):
+        """When no close match, the error should list defined variables."""
+        with pytest.raises(ValueError, match=r"(Did you mean|Variables defined)"):
+            with Graph('g5') as g:
+                sentence = Concept('sentence')
+                word = Concept('word')
+                tag = Concept('tag')
+                (s_w,) = sentence.contains(word)
+                (w_t,) = word.contains(tag)
+                ifL(
+                    word('w1'),
+                    notL(tag('t1', path=(('xyz', s_w, w_t),)))
+                )
+
+
+# ---------- valid constraints still pass ----------
+
+class TestValidConstraintsStillWork:
+    def test_correct_variable_no_error(self):
+        """A properly defined variable should not raise."""
+        with Graph('g_ok') as g:
+            sentence = Concept('sentence')
+            word = Concept('word')
+            tag = Concept('tag')
+            (s_w,) = sentence.contains(word)
+            (w_t,) = word.contains(tag)
+            ifL(
+                word('w1'),
+                notL(tag('t1', path=('w1', s_w, w_t)))
+            )
+        # reaching here = no error, test passes
+
+    def test_nandL_valid(self):
+        """nandL with properly defined concepts must not raise."""
+        with Graph('g_nand') as g:
+            w = Concept('word')
+            people = w(name='people')
+            org = w(name='organization')
+            nandL(people, org, active=True)
+        # reaching here = no error
+
+
+# ---------- error type consistency ----------
+
+class TestErrorTypeConsistency:
+    def test_all_lc_errors_are_valueerror(self):
+        """Verify that validation errors from the LC checker are ValueError, not bare Exception."""
+        # Trigger a path validation error — 'nosuchvar' is not defined anywhere
+        with pytest.raises(ValueError):
+            with Graph('g_card') as g:
+                w = Concept('word')
+                tag = Concept('tag')
+                (w_t,) = w.contains(tag)
+                ifL(
+                    w('x'),
+                    notL(tag('t', path=('nosuchvar', w_t)))
+                )
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
Adds `iffL` (if-and-only-if) biconditional constraint to DomiKnowS.

## What this does
- Adds `iffL` as a user-friendly alias for `equivalenceL` (A ↔ B)
- Exports `iffL` from graph-level imports
- Adds documentation with usage examples
- Adds regression tests

## Semantics
| A | B | Result |
|---|---|--------|
| True | True | ✅ satisfied |
| False | False | ✅ satisfied |
| True | False | ❌ violated |
| False | True | ❌ violated |

## Tests
Added `test_iff_constraint.py` — all tests pass locally.

Closes #378

Co-authored-by: nik464 <nikhil18chaudhary@gmail.com>