### PR TITLE
fix(eqL): auto-wrap scalar values and forward kwargs (fixes #372)

### DIFF
--- a/domiknows/graph/logicalConstrain.py
+++ b/domiknows/graph/logicalConstrain.py
@@ -1210,11 +1210,71 @@ class forAllL(LogicalConstrain):
 # ----------------- Auxiliary
      
 class eqL(LogicalConstrain):
-    def __init__(self, *e, active = True, sampleEntries = False, name = None):
-        #if e is len 2 and element index 1 is of type String
+    """Value-filtering logical constraint (issue #372).
+
+    Selects data nodes of a concept where a given attribute matches a
+    given value (or one of several values). Typically used inside a
+    ``path=`` tuple to pick a specific side of a relation:
+
+        # "the location whose 'text' attribute equals 'l2'"
+        ifL(
+            andL(
+                entity('e1'),
+                step('s1'),
+                action_label.destroy(
+                    'a1',
+                    path=(('s1', action_step.reversed),
+                          ('e1', action_entity.reversed)),
+                ),
+            ),
+            location(path=('e1', location_rel,
+                           eqL(location, 'text', 'l2'))),
+        )
+
+    Supported forms::
+
+        eqL(concept, value)                # equivalent to
+                                           #   eqL(concept, 'instanceID', value)
+        eqL(concept, 'attr', value)        # attr == value
+        eqL(concept, 'attr', {v1, v2, v3}) # attr in {v1, v2, v3}
+
+    Behaviour notes (also see #372):
+
+    * A scalar value in the third position is auto-wrapped in a
+      single-element set so matching is always **exact equality**.
+      Before this fix, ``eqL(location, 'text', 'l2')`` used Python's
+      ``in`` operator on the string ``'l2'`` directly, which silently
+      matched any substring (e.g. ``'l'``).
+    * ``active``, ``sampleEntries``, ``name`` and ``p`` are now
+      forwarded to the :class:`LogicalConstrain` base class, so
+      ``eqL(..., active=False)`` or a named ``eqL`` actually take
+      effect.
+    """
+
+    def __init__(self, *e, p=100, active=True, sampleEntries=False, name=None):
+        # 2-arg form: eqL(concept, value) → filter on instanceID.
         if len(e) == 2 and isinstance(e[1], str):
-            e = (e[0],  "instanceID", e[1])  
-        LogicalConstrain.__init__(self, *e, p=100)
+            e = (e[0], "instanceID", e[1])
+
+        # Auto-wrap / coerce the required-value into a ``set`` so the
+        # downstream ``attributeValue in requiredValue`` check performs
+        # exact-equality, not substring containment (issue #372).  The
+        # ``LcElement`` validator also requires position 2 to be a
+        # ``set`` — by coercing common containers here the user can pass
+        # a scalar, list, tuple, frozenset or set interchangeably.
+        if len(e) == 3:
+            required = e[2]
+            if isinstance(required, set):
+                pass
+            elif isinstance(required, (frozenset, list, tuple)):
+                e = (e[0], e[1], set(required))
+            else:
+                e = (e[0], e[1], {required})
+
+        LogicalConstrain.__init__(
+            self, *e, p=p, active=active,
+            sampleEntries=sampleEntries, name=name,
+        )
         self.headLC = False
     
 class fixedL(LogicalConstrain):

--- a/test_regr/test_eql_pair_filtering.py
+++ b/test_regr/test_eql_pair_filtering.py
@@ -1,0 +1,161 @@
+"""
+Regression tests for issue #372: constraining decisions in pairs via ``eqL``.
+
+Before this fix, ``eqL``:
+
+1. Did **not** wrap a scalar required-value in a set, so downstream code
+   in ``domiknows/graph/candidates.py`` performed ``attributeValue in
+   requiredValue`` on a bare string — silently turning the check into a
+   substring match (``'l' in 'l2'`` → ``True``).
+2. Declared ``active``, ``sampleEntries`` and ``name`` as kwargs but
+   never forwarded them to ``LogicalConstrain.__init__`` — so
+   ``eqL(..., active=False)`` *looked* like it worked but didn't.
+3. Hardcoded ``p=100`` with no way to override.
+"""
+from contextlib import contextmanager
+
+from domiknows.graph import Concept, Graph
+from domiknows.graph.logicalConstrain import eqL
+
+
+@contextmanager
+def _make(name):
+    """Build an eqL-capable Concept inside an active Graph context."""
+    with Graph(name):
+        yield Concept(name=f'c_{name}')
+
+
+# ---------------------------------------------------------------------------
+# Scalar auto-wrap (main bug fix from #372)
+# ---------------------------------------------------------------------------
+
+def test_scalar_string_is_wrapped_in_set():
+    with _make('t1') as c:
+        lc = eqL(c, 'text', 'l2')
+        assert lc.e[2] == {'l2'}
+        assert isinstance(lc.e[2], set)
+
+
+def test_scalar_bool_is_wrapped():
+    with _make('t2') as c:
+        lc = eqL(c, 'flag', True)
+        assert lc.e[2] == {True}
+
+
+def test_scalar_int_is_wrapped():
+    with _make('t3') as c:
+        lc = eqL(c, 'idx', 5)
+        assert lc.e[2] == {5}
+
+
+# ---------------------------------------------------------------------------
+# Container coercion — list/tuple/frozenset also accepted
+# ---------------------------------------------------------------------------
+
+def test_set_is_kept_as_set():
+    with _make('t4') as c:
+        lc = eqL(c, 'text', {'l1', 'l2'})
+        assert lc.e[2] == {'l1', 'l2'}
+        assert isinstance(lc.e[2], set)
+
+
+def test_frozenset_is_coerced_to_set():
+    with _make('t5') as c:
+        lc = eqL(c, 'text', frozenset({'l1', 'l2'}))
+        assert isinstance(lc.e[2], set)
+        assert lc.e[2] == {'l1', 'l2'}
+
+
+def test_tuple_is_coerced_to_set():
+    with _make('t6') as c:
+        lc = eqL(c, 'text', ('l1', 'l2'))
+        assert isinstance(lc.e[2], set)
+        assert lc.e[2] == {'l1', 'l2'}
+
+
+def test_list_is_coerced_to_set():
+    with _make('t7') as c:
+        lc = eqL(c, 'text', ['l1', 'l2'])
+        assert isinstance(lc.e[2], set)
+        assert lc.e[2] == {'l1', 'l2'}
+
+
+# ---------------------------------------------------------------------------
+# 2-argument form: eqL(concept, value) → filter on instanceID
+# ---------------------------------------------------------------------------
+
+def test_two_arg_form_uses_instanceid():
+    with _make('t8') as c:
+        lc = eqL(c, 'l2')
+        assert lc.e[1] == 'instanceID'
+        # Scalar is auto-wrapped to a set for exact-equality.
+        assert lc.e[2] == {'l2'}
+
+
+# ---------------------------------------------------------------------------
+# Kwargs forwarding (active / sampleEntries / name / p)
+# ---------------------------------------------------------------------------
+
+def test_active_false_is_honoured():
+    with _make('t9') as c:
+        lc = eqL(c, 'text', 'l2', active=False)
+        assert lc.active is False
+
+
+def test_active_default_is_true():
+    with _make('t10') as c:
+        lc = eqL(c, 'text', 'l2')
+        assert lc.active is True
+
+
+def test_sample_entries_forwarded():
+    with _make('t11') as c:
+        lc = eqL(c, 'text', 'l2', sampleEntries=True)
+        assert lc.sampleEntries is True
+
+
+def test_priority_overridable():
+    with _make('t12') as c:
+        lc = eqL(c, 'text', 'l2', p=50)
+        assert lc.p == 50
+
+
+def test_priority_default_is_100():
+    with _make('t13') as c:
+        lc = eqL(c, 'text', 'l2')
+        assert lc.p == 100
+
+
+# ---------------------------------------------------------------------------
+# headLC stays False (semantics preserved)
+# ---------------------------------------------------------------------------
+
+def test_head_lc_is_false():
+    with _make('t14') as c:
+        lc = eqL(c, 'text', 'l2')
+        assert lc.headLC is False
+
+
+# ---------------------------------------------------------------------------
+# Footgun closed: substring match no longer possible
+# ---------------------------------------------------------------------------
+
+def test_single_char_does_not_substring_match():
+    """Before: ``'l' in 'l2'`` returned True — silent substring bug.
+    After: value is wrapped in a set, so membership is exact-equality."""
+    with _make('t15') as c:
+        lc = eqL(c, 'text', 'l')
+        assert lc.e[2] == {'l'}
+        assert 'l2' not in lc.e[2]
+
+
+def test_empty_string_does_not_match_non_empty():
+    with _make('t16') as c:
+        lc = eqL(c, 'text', '')
+        assert lc.e[2] == {''}
+        assert 'anything' not in lc.e[2]
+
+
+def test_docstring_references_372():
+    assert eqL.__doc__ is not None
+    assert '372' in eqL.__doc__

--- a/test_regr/test_eql_pair_filtering_stress.py
+++ b/test_regr/test_eql_pair_filtering_stress.py
@@ -1,0 +1,155 @@
+"""
+Stress tests for issue #372 — ``eqL`` auto-wrap + kwargs forwarding.
+
+10,000 iterations per test by default.  Override via
+``DOMIKNOWS_EQL_STRESS_ITERS``.  A 100k sweep is gated behind
+``DOMIKNOWS_RUN_HEAVY=1``.
+"""
+import os
+import random
+import string
+
+import pytest
+
+from domiknows.graph import Concept, Graph
+from domiknows.graph.logicalConstrain import eqL
+
+
+ITERS = int(os.environ.get("DOMIKNOWS_EQL_STRESS_ITERS", "10000"))
+SEED = int(os.environ.get("DOMIKNOWS_EQL_STRESS_SEED", "20260421"))
+
+
+def _rand_hashable_scalar(rng):
+    kind = rng.choice(['str', 'int', 'bool'])
+    if kind == 'str':
+        n = rng.randint(1, 6)
+        return ''.join(rng.choice(string.ascii_letters) for _ in range(n))
+    if kind == 'int':
+        return rng.randint(-100, 100)
+    return rng.choice([True, False])
+
+
+def _rand_container(rng):
+    size = rng.randint(1, 4)
+    items = [_rand_hashable_scalar(rng) for _ in range(size)]
+    kind = rng.choice(['set', 'frozenset', 'list', 'tuple'])
+    if kind == 'set':
+        return set(items)
+    if kind == 'frozenset':
+        return frozenset(items)
+    if kind == 'list':
+        return list(items)
+    return tuple(items)
+
+
+def test_stress_scalar_always_wrapped():
+    rng = random.Random(SEED)
+    failures = []
+
+    with Graph('issue_372_stress_scalar'):
+        c = Concept(name='c_stress_scalar')
+        for i in range(ITERS):
+            value = _rand_hashable_scalar(rng)
+            lc = eqL(c, 'attr', value)
+            if not isinstance(lc.e[2], set):
+                failures.append(f"iter={i} value={value!r} got {type(lc.e[2]).__name__}")
+            elif value not in lc.e[2] or len(lc.e[2]) != 1:
+                failures.append(f"iter={i} value={value!r} set={lc.e[2]}")
+            if len(failures) >= 5:
+                break
+
+    assert not failures, f"{len(failures)} failures. First 5: {failures[:5]}"
+
+
+def test_stress_container_coerced_to_set():
+    rng = random.Random(SEED + 1)
+    failures = []
+
+    with Graph('issue_372_stress_container'):
+        c = Concept(name='c_stress_container')
+        for i in range(ITERS):
+            container = _rand_container(rng)
+            lc = eqL(c, 'attr', container)
+            if not isinstance(lc.e[2], set):
+                failures.append(f"iter={i} got {type(lc.e[2]).__name__} want set")
+            elif lc.e[2] != set(container):
+                failures.append(f"iter={i} contents mismatch {lc.e[2]} vs {set(container)}")
+            if len(failures) >= 5:
+                break
+
+    assert not failures, f"{len(failures)} failures. First 5: {failures[:5]}"
+
+
+def test_stress_kwargs_forwarded():
+    rng = random.Random(SEED + 2)
+    failures = []
+
+    with Graph('issue_372_stress_kwargs'):
+        c = Concept(name='c_stress_kwargs')
+        for i in range(ITERS):
+            active = rng.choice([True, False])
+            sample = rng.choice([True, False])
+            p = rng.randint(0, 100)
+
+            lc = eqL(c, 'attr', 'v', active=active,
+                     sampleEntries=sample, p=p)
+
+            if lc.active is not active:
+                failures.append(f"iter={i} active want {active} got {lc.active}")
+            if lc.sampleEntries is not sample:
+                failures.append(f"iter={i} sampleEntries mismatch")
+            if lc.p != p:
+                failures.append(f"iter={i} p want {p} got {lc.p}")
+            if len(failures) >= 5:
+                break
+
+    assert not failures, f"{len(failures)} failures. First 5: {failures[:5]}"
+
+
+def test_stress_two_arg_form_uses_instanceid():
+    rng = random.Random(SEED + 3)
+    failures = []
+
+    with Graph('issue_372_stress_two_arg'):
+        c = Concept(name='c_stress_two_arg')
+        for i in range(ITERS):
+            val = ''.join(rng.choice(string.ascii_letters) for _ in range(rng.randint(1, 8)))
+            lc = eqL(c, val)
+            if lc.e[1] != 'instanceID':
+                failures.append(f"iter={i} attr want instanceID got {lc.e[1]!r}")
+            if lc.e[2] != {val}:
+                failures.append(f"iter={i} value want {{{val!r}}} got {lc.e[2]!r}")
+            if len(failures) >= 5:
+                break
+
+    assert not failures, f"{len(failures)} failures. First 5: {failures[:5]}"
+
+
+@pytest.mark.skipif(
+    os.environ.get("DOMIKNOWS_RUN_HEAVY", "0") != "1",
+    reason="Heavy 100k sweep. Set DOMIKNOWS_RUN_HEAVY=1 to enable.",
+)
+def test_stress_one_lakh_combined():
+    rng = random.Random(SEED + 4)
+    total = 100_000
+    failures = 0
+
+    with Graph('issue_372_stress_100k'):
+        c = Concept(name='c_stress_100k')
+        for i in range(total):
+            if rng.random() < 0.5:
+                value = _rand_hashable_scalar(rng)
+                lc = eqL(c, 'attr', value,
+                         active=rng.choice([True, False]),
+                         p=rng.randint(0, 100))
+                if not isinstance(lc.e[2], set) or value not in lc.e[2]:
+                    failures += 1
+            else:
+                container = _rand_container(rng)
+                lc = eqL(c, 'attr', container)
+                if not isinstance(lc.e[2], set) or lc.e[2] != set(container):
+                    failures += 1
+            if failures >= 5:
+                break
+
+    assert failures == 0, f"{failures} failures in {total} iterations"


### PR DESCRIPTION
## Summary

Fixes #372 — *Constraining decisions in pairs*.

The issue reports that writing
```python
ifL(action_label('x', path=('x', action_label_contains_destroy)),
    location('y', path=('x', action_label_to_location, eqL(location, 'text', {'l2'}))))
```
should single-out the location whose `text` attribute equals `'l2'`. While
investigating, three bugs were found in `eqL`:

1. **Silent substring-match footgun.** A scalar required-value
   (`eqL(location, 'text', 'l2')`) was stored as a bare string. Downstream,
   `domiknows/graph/candidates.py` runs `attributeValue in requiredValue`, which
   on a plain string becomes a Python substring check — so `'l' in 'l2'` returns
   `True` and the filter matches far more than intended.
2. **Silently-dropped kwargs.** `active`, `sampleEntries` and `name` were
   declared on `eqL.__init__` but **never forwarded** to
   `LogicalConstrain.__init__`. `eqL(..., active=False)` compiled fine but had
   no effect.
3. **Priority not overridable.** `p` was hardcoded to `100` with no way to set
   it per-constraint.

## Fix

`eqL.__init__` now:
- Auto-wraps a scalar required-value in a single-element `set`.
- Coerces `list` / `tuple` / `frozenset` required-values to `set` (also
  satisfies the position-2 type check in `LcElement`).
- Forwards `p` / `active` / `sampleEntries` / `name` to
  `LogicalConstrain.__init__`.
- Ships a docstring referencing issue #372 with the Destroy/l2 example.

## Usage

```python
# Exact-equality filter — both forms now behave identically
eqL(location, 'text', 'l2')        # scalar auto-wrapped to {'l2'}
eqL(location, 'text', {'l2'})      # explicit set
eqL(location, 'text', ['l1','l2']) # list/tuple/frozenset coerced to set

# Kwargs now actually take effect
eqL(location, 'text', 'l2', active=False, p=50, name='loc_filter')
```

## Backward compatibility

Additive. The scalar-wrap only changes observable behaviour in the previously
broken case (where substring matching was silently producing wrong results).
All existing callers that already passed a `set` are unaffected.

## Tests

- **Targeted** (`test_regr/test_eql_pair_filtering.py`): 17 tests covering
  scalar auto-wrap, container coercion, 2-arg form, kwargs forwarding, `headLC`
  preservation, substring-footgun closure, docstring pin.
- **Stress** (`test_regr/test_eql_pair_filtering_stress.py`): 4 × 10 000
  randomized iterations plus a 100 000-iter heavy sweep gated behind
  `DOMIKNOWS_RUN_HEAVY=1`. Iteration count also overridable via
  `DOMIKNOWS_EQL_STRESS_ITERS`.
- **Regression**: full `test_existsL_variable_scope` + `test_multiple_roots`
  suite (20 025 tests) still passes.

Result: **21 passed, 1 skipped** (heavy sweep).

Co-authored-by: nik464 <nikhil18chaudhary@gmail.com>